### PR TITLE
Audit use of GC preserve

### DIFF
--- a/src/gzip.jl
+++ b/src/gzip.jl
@@ -317,7 +317,7 @@ function unsafe_gzip_decompress!(
     length(out_data) < uncompressed_size && resize!(out_data, uncompressed_size)
 
     # Now DEFLATE decompress
-    decomp_result = unsafe_decompress!(
+    decomp_result = GC.@preserve out_data unsafe_decompress!(
         Base.HasLength(),
         decompressor,
         pointer(out_data),
@@ -329,7 +329,7 @@ function unsafe_gzip_decompress!(
 
     # Check for CRC checksum and validate it
     crc_exp = ltoh(unsafe_load(Ptr{UInt32}(in_ptr + len - UInt(8))))
-    crc_obs = unsafe_crc32(pointer(out_data), uncompressed_size % Int)
+    crc_obs = GC.@preserve out_data unsafe_crc32(pointer(out_data), uncompressed_size % Int)
     crc_exp == crc_obs || return LibDeflateErrors.gzip_bad_crc32
 
     return GzipDecompressResult(uncompressed_size, header)

--- a/src/zlib.jl
+++ b/src/zlib.jl
@@ -1,5 +1,5 @@
 # Single-line boxes show the number of bytes, double-lined have
-# a variable number of bytes. E.g. here: 1, 1, 4, N, 4.
+# a variable number of bytes. E.g. here: 1, 1, N, 4.
 # +---+---+===============+---+---+---+---+
 # |CMF|FLG|COMPRESSED DATA|     ADLER32   |    
 # +---+---+===============+---+---+---+---+


### PR DESCRIPTION
Julia requires use of GC preserve whenever we take a pointer, but the code didn't do this.
Although it currently has no effect and is compiled to a noop, that might change in the future.